### PR TITLE
bugfix/PP-13303: Shopware 6 Transaction Issues

### DIFF
--- a/PayrexxPaymentGatewaySW6/src/Handler/PaymentHandler.php
+++ b/PayrexxPaymentGatewaySW6/src/Handler/PaymentHandler.php
@@ -174,6 +174,8 @@ class PaymentHandler implements AsynchronousPaymentHandlerInterface
             if (!$payrexxGateway) {
                 throw new Exception('Gateway creation error');
             }
+            $oldGatewayId = $orderTransaction->getCustomFields()['gateway_id'] ?? '';
+            $this->payrexxApiService->deletePayrexxGateway($salesChannelId, $oldGatewayId);
             $this->transactionHandler->saveTransactionCustomFields($salesChannelContext, $transactionId, ['gateway_id' => $payrexxGateway->getId()]);
             $this->transactionHandler->handleTransactionStatus(
                 $orderTransaction,
@@ -216,6 +218,7 @@ class PaymentHandler implements AsynchronousPaymentHandlerInterface
         }
 
         $gatewayIds = explode(',', (string) $gatewayId);
+        // delete gateway
         $payrexxGateway = $this->payrexxApiService->getPayrexxGateway(current($gatewayIds), $salesChannelContext->getSalesChannel()->getId());
         $payrexxTransaction = $this->payrexxApiService->getTransactionByGateway($payrexxGateway, $salesChannelContext->getSalesChannel()->getId());
 

--- a/PayrexxPaymentGatewaySW6/src/Handler/PaymentHandler.php
+++ b/PayrexxPaymentGatewaySW6/src/Handler/PaymentHandler.php
@@ -161,7 +161,6 @@ class PaymentHandler implements AsynchronousPaymentHandlerInterface
         if (in_array($paymentMean, ['sofortueberweisung_de', 'postfinance_card', 'postfinance_efinance'])) {
             throw new Exception('Unavailable payment method error');
         }
-
         // Create Payrexx Gateway link for checkout and redirect user
         try {
             $payrexxGateway = $this->payrexxApiService->createPayrexxGateway(

--- a/PayrexxPaymentGatewaySW6/src/Handler/TransactionHandler.php
+++ b/PayrexxPaymentGatewaySW6/src/Handler/TransactionHandler.php
@@ -65,22 +65,6 @@ class TransactionHandler
     {
         $transactionRepo = $this->container->get('order_transaction.repository');
 
-        // Manage existing gateway ids.
-        $criteria = new Criteria([$transactionId]);
-        $criteria->addAssociation('customFields');
-        $transaction = $transactionRepo->search($criteria, $salesChannelContext->getContext())->first();
-        if ($transaction) {
-            $customFields = $transaction->getCustomFields() ?? [];
-            $gatewayIds = $customFields['gateway_id'] ?? '';
-
-            if (!empty($gatewayIds)) {
-                // Save new gateway id first.
-                $newGatewayId = $details['gateway_id'] . ',' . $gatewayIds;
-                $newGatewayIds = array_slice(explode(',', $newGatewayId), 0, 5);
-                $details['gateway_id'] = implode(',', $newGatewayIds);
-            }
-        }
-
         $transactionRepo->upsert([[
             'id' => $transactionId,
             'customFields' => $details

--- a/PayrexxPaymentGatewaySW6/src/Handler/TransactionHandler.php
+++ b/PayrexxPaymentGatewaySW6/src/Handler/TransactionHandler.php
@@ -104,11 +104,15 @@ class TransactionHandler
             case Transaction::CANCELLED:
             case Transaction::DECLINED:
             case Transaction::EXPIRED:
-                if ($state !== null && in_array($orderTransaction->getStateMachineState()->getTechnicalName(), [OrderTransactionStates::STATE_CANCELLED, OrderTransactionStates::STATE_PAID])) break;
+                if ($state !== null && !in_array($orderTransaction->getStateMachineState()->getTechnicalName(), [OrderTransactionStates::STATE_OPEN, OrderTransactionStates::STATE_UNCONFIRMED])) {
+                    break;
+                }
                 $this->transactionStateHandler->cancel($orderTransaction->getId(), $context);
                 break;
             case Transaction::ERROR:
-                if ($state !== null && in_array($orderTransaction->getStateMachineState()->getTechnicalName(), [OrderTransactionStates::STATE_FAILED, OrderTransactionStates::STATE_PAID])) break;
+                if ($state !== null && !in_array($orderTransaction->getStateMachineState()->getTechnicalName(), [OrderTransactionStates::STATE_OPEN, OrderTransactionStates::STATE_UNCONFIRMED])) {
+                    break;
+                }
                 $this->transactionStateHandler->fail($orderTransaction->getId(), $context);
                 break;
         }

--- a/PayrexxPaymentGatewaySW6/src/Service/PayrexxApiService.php
+++ b/PayrexxPaymentGatewaySW6/src/Service/PayrexxApiService.php
@@ -198,10 +198,10 @@ class PayrexxApiService
     /**
      * Delete the payrexx gateway
      *
-     * @param string $gatewayId
      * @param string $salesChannelId
+     * @param int $gatewayId
      */
-    public function deletePayrexxGateway(string $gatewayId, string $salesChannelId): void
+    public function deletePayrexxGateway(string $salesChannelId, int $gatewayId): void
     {
         if (empty($gatewayId)) {
             return;

--- a/PayrexxPaymentGatewaySW6/src/Service/PayrexxApiService.php
+++ b/PayrexxPaymentGatewaySW6/src/Service/PayrexxApiService.php
@@ -209,7 +209,7 @@ class PayrexxApiService
 
         $payrexx = $this->getInterface($salesChannelId);
         $gateway = $this->getPayrexxGateway($gatewayId, $salesChannelId);
-        if ($payrexx && $gateway && !$gateway->getInvoices()) {
+        if ($payrexx && $gateway && !$this->getTransactionByGateway($salesChannelId, $gatewayId)) {
             try {
                 $payrexx->delete($gateway);
             } catch (\Payrexx\PayrexxException $e) {

--- a/PayrexxPaymentGatewaySW6/src/Service/PayrexxApiService.php
+++ b/PayrexxPaymentGatewaySW6/src/Service/PayrexxApiService.php
@@ -200,21 +200,28 @@ class PayrexxApiService
      *
      * @param string $salesChannelId
      * @param int $gatewayId
+     * @return bool
      */
-    public function deletePayrexxGateway(string $salesChannelId, int $gatewayId): void
+    public function deletePayrexxGateway(string $salesChannelId, int $gatewayId): bool
     {
         if (empty($gatewayId)) {
-            return;
+            return true;
         }
 
         $payrexx = $this->getInterface($salesChannelId);
         $gateway = $this->getPayrexxGateway($gatewayId, $salesChannelId);
-        if ($payrexx && $gateway && !$this->getTransactionByGateway($salesChannelId, $gatewayId)) {
+
+        if (!$gateway) {
+            return true; // Already deleted.
+        }
+        if ($payrexx && $gateway && !$this->getTransactionByGateway($gateway, $salesChannelId)) {
             try {
                 $payrexx->delete($gateway);
+                return true;
             } catch (\Payrexx\PayrexxException $e) {
-                return;
+                // no action.
             }
         }
+        return false;
     }
 }

--- a/PayrexxPaymentGatewaySW6/src/Service/PayrexxApiService.php
+++ b/PayrexxPaymentGatewaySW6/src/Service/PayrexxApiService.php
@@ -194,4 +194,27 @@ class PayrexxApiService
             return null;
         }
     }
+
+    /**
+     * Delete the payrexx gateway
+     *
+     * @param string $gatewayId
+     * @param string $salesChannelId
+     */
+    public function deletePayrexxGateway(string $gatewayId, string $salesChannelId): void
+    {
+        if (empty($gatewayId)) {
+            return;
+        }
+
+        $payrexx = $this->getInterface($salesChannelId);
+        $gateway = $this->getPayrexxGateway($gatewayId, $salesChannelId);
+        if ($payrexx && $gateway && !$gateway->getInvoices()) {
+            try {
+                $payrexx->delete($gateway);
+            } catch (\Payrexx\PayrexxException $e) {
+                return;
+            }
+        }
+    }
 }


### PR DESCRIPTION
The customer tries to pay or cancel the old gateways. so the multiple gateways are saved in the custom fields to process the webhook response.


I have implemented the functionality to remove the old gateway ID. If the customer tries to change the payment method and retry to pay.

Additionally, improved the transition status check for cancel and failed statuses.