### PR TITLE
bugfix/PP-13801: Shopware 6: Orders With Amount 0 (Zero) Cannot Be Processed

### DIFF
--- a/PayrexxPaymentGatewaySW6/CHANGELOG.md
+++ b/PayrexxPaymentGatewaySW6/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.0.45]
+### Fixed
+- Bug fix: Resolved an issue for order amount is 0.
+
 ## [1.0.44]
 ### Fixed
 - Bug fix: Resolved an issue where deleting a payment gateway for transition change.

--- a/PayrexxPaymentGatewaySW6/composer.json
+++ b/PayrexxPaymentGatewaySW6/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "payrexx/payment",
   "description": "A Shopware plugin to accept payments with Payrexx",
-  "version": "1.0.44",
+  "version": "1.0.45",
   "type": "shopware-platform-plugin",
   "license": "MIT",
   "authors": [

--- a/PayrexxPaymentGatewaySW6/src/Handler/PaymentHandler.php
+++ b/PayrexxPaymentGatewaySW6/src/Handler/PaymentHandler.php
@@ -239,17 +239,21 @@ class PaymentHandler implements AsynchronousPaymentHandlerInterface
         $salesChannelId = $salesChannelContext->getSalesChannel()->getId();
 
         $orderTransaction = $shopwareTransaction->getOrderTransaction();
-        $customFields = $orderTransaction->getCustomFields();
-        $gatewayId = $customFields['gateway_id'];
         $transactionId = $orderTransaction->getId();
         $totalAmount = $orderTransaction->getAmount()->getTotalPrice();
 
         if ($totalAmount <= 0) {
-            if (OrderTransactionStates::STATE_PAID === $orderTransaction->getStateMachineState()->getTechnicalName()) return;
+            if ($orderTransaction->getStateMachineState() &&
+                OrderTransactionStates::STATE_PAID === $orderTransaction->getStateMachineState()->getTechnicalName()
+            ) {
+                return;
+            }
             $this->transactionStateHandler->paid($orderTransaction->getId(), $context);
             return;
         }
 
+        $customFields = $orderTransaction->getCustomFields();
+        $gatewayId = $customFields['gateway_id'] ?? '';
         if (empty($gatewayId)) {
             $this->customCustomerException($transactionId, 'Customer canceled the payment on the Payrexx page');
         }


### PR DESCRIPTION
**Test case 1:**

If the order total amount is 0, the order status is set as paid. 