### PR TITLE
bugfix/PP-16330: Shopware Webhook Status Change Bug

### DIFF
--- a/PayrexxPaymentGatewaySW6/CHANGELOG.md
+++ b/PayrexxPaymentGatewaySW6/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [2.0.2]
+### Improvement
+- Improved the webhook to check paid state.
+
 ## [2.0.1]
 ### Fixed
 - Delete payment gateway and manage gateway ids.

--- a/PayrexxPaymentGatewaySW6/composer.json
+++ b/PayrexxPaymentGatewaySW6/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "payrexx/payment",
   "description": "A Shopware plugin to accept payments with Payrexx",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "type": "shopware-platform-plugin",
   "license": "MIT",
   "authors": [

--- a/PayrexxPaymentGatewaySW6/src/Webhook/Dispatcher.php
+++ b/PayrexxPaymentGatewaySW6/src/Webhook/Dispatcher.php
@@ -113,7 +113,7 @@ class Dispatcher
                 $state = $orderTransaction->getStateMachineState();
 
                 if ($state && $state->getTechnicalName() === OrderTransactionStates::STATE_PAID) {
-                    return new Response('Already Paid state', Response::HTTP_OK);
+                    return new Response('Already Paid State', Response::HTTP_OK);
                 }
                 $savedGatewayIds = explode(',', (string) $orderTransaction->getCustomFields()['gateway_id']);
                 if (in_array($requestGatewayId, $savedGatewayIds)) {

--- a/PayrexxPaymentGatewaySW6/src/Webhook/Dispatcher.php
+++ b/PayrexxPaymentGatewaySW6/src/Webhook/Dispatcher.php
@@ -49,7 +49,7 @@ class Dispatcher
         ConfigService $configService,
         PayrexxApiService $payrexxApiService,
         TransactionHandler $transactionHandler,
-                                     $logger
+        LoggerInterface $logger
     )
     {
         $this->transactionStateHandler = $transactionStateHandler;


### PR DESCRIPTION
**Test case 1:**

1. Set PayrexxApiService::deletePayrexxGateway() { return false; }
2. Checkout the product and be redirected to Payrexx.
3. Copy the Payrexx payment URL (redirected URL).
4. Click the browser back button and change the payment method.
5. Redirected the payment gateway and paid successfully.
6. Checked the Shopware backend, the order transaction is updated successfully.
7. Loaded the copied payment URL and filled in the card number for the failed transaction.
8. Checked the Shopware backend, the failed payment status was not updated.

Once paid, the transaction status is not updated.