### PR TITLE
task/PP-16948: Add Payment Method VERD.cash in Shopware 6

### DIFF
--- a/PayrexxPaymentGatewaySW6/CHANGELOG.md
+++ b/PayrexxPaymentGatewaySW6/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [2.1.3]
+### Info
+- Added a new payment method for VERD.cash.
+
 ## [2.1.2]
 ### Info
 - Added a new payment method for Crypto.

--- a/PayrexxPaymentGatewaySW6/composer.json
+++ b/PayrexxPaymentGatewaySW6/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "payrexx/payment",
   "description": "A Shopware plugin to accept payments with Payrexx",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "type": "shopware-platform-plugin",
   "license": "MIT",
   "authors": [

--- a/PayrexxPaymentGatewaySW6/src/Installer/Modules/PaymentMethodInstaller.php
+++ b/PayrexxPaymentGatewaySW6/src/Installer/Modules/PaymentMethodInstaller.php
@@ -68,6 +68,7 @@ class PaymentMethodInstaller implements InstallerInterface
     public const PAYREXX_POWERPAY           = 'powerpay';
     public const PAYREXX_CEMBRAPAY          = 'cembrapay';
     public const PAYREXX_CRYPTO             = 'crypto';
+    public const PAYREXX_VERD_CASH          = 'verd-cash';
     public const PAYREXX_NO_PM              = '';
 
     const PAYMENT_METHODS = [
@@ -518,6 +519,16 @@ class PaymentMethodInstaller implements InstallerInterface
                 ],
                 'en-GB' => [
                     'name' => 'Crypto',
+                ],
+            ],
+        ],
+        self::PAYREXX_VERD_CASH => [
+            'translations' => [
+                'de-DE' => [
+                    'name' => 'VERD.Cash',
+                ],
+                'en-GB' => [
+                    'name' => 'VERD.Cash',
                 ],
             ],
         ],


### PR DESCRIPTION
- Added new payment method VERD.cash

On checkout, the payment method is shown on the checkout page.