### PR TITLE
bugfix/PP-19216: Basket Not Shown Correctly in the Transaction Details (shopware 6)

### DIFF
--- a/PayrexxPaymentGatewaySW6/CHANGELOG.md
+++ b/PayrexxPaymentGatewaySW6/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [2.1.14]
+### Improvement
+- Improved the code to handle one-cent differences during amount comparison.
+
 ## [2.1.13]
 ### Improvement
 - Upgraded the Payrexx SDK.

--- a/PayrexxPaymentGatewaySW6/composer.json
+++ b/PayrexxPaymentGatewaySW6/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "payrexx/payment",
   "description": "A Shopware plugin to accept payments with Payrexx",
-  "version": "2.1.13",
+  "version": "2.1.14",
   "type": "shopware-platform-plugin",
   "license": "MIT",
   "authors": [

--- a/PayrexxPaymentGatewaySW6/src/Handler/PaymentHandler.php
+++ b/PayrexxPaymentGatewaySW6/src/Handler/PaymentHandler.php
@@ -341,7 +341,7 @@ class PaymentHandler extends AbstractPaymentHandler
             $amount = $product['amount'];
             $basketAmount += $product['quantity'] * $amount;
         }
-        return intval($basketAmount);
+        return intval((string) $basketAmount);
     }
 
     /**


### PR DESCRIPTION
While comparing the basket amount total and the order total, one cent is missing.